### PR TITLE
S200 unicode

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/adapter/GBDeviceAdapterv2.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/adapter/GBDeviceAdapterv2.java
@@ -22,15 +22,19 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
+import android.text.InputType;
 import android.transition.TransitionManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
@@ -134,6 +138,45 @@ public class GBDeviceAdapterv2 extends RecyclerView.Adapter<GBDeviceAdapterv2.Vi
                 holder.batteryIcon.setImageLevel(device.getBatteryLevel());
             }
         }
+        //Alberto soglia
+        holder.batteryStatusBox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                final SharedPreferences prefs = GBApplication.getPrefs().getPreferences();
+                final EditText input = new EditText(context);
+                float dpi = context.getResources().getDisplayMetrics().density;
+                FrameLayout container = new FrameLayout(context);
+
+                AlertDialog.Builder alertDialog = new AlertDialog.Builder(context);
+                alertDialog.setTitle(context.getString(R.string.pref_title_battery_percent));
+
+                FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+                params.leftMargin = (int) (20 * dpi);
+                params.rightMargin = (int) (20 * dpi);
+
+                input.setInputType(InputType.TYPE_CLASS_NUMBER);
+                input.setText(String.valueOf(prefs.getInt(device.getAddress() + "_battery_percent", device.getBatteryThresholdPercent())));
+                input.setLayoutParams(params);
+
+                container.addView(input);
+
+                alertDialog.setView(container); // uncomment this line
+                alertDialog.setPositiveButton("Ok",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                int level = Integer.valueOf(input.getText().toString());
+
+                                SharedPreferences.Editor editor = prefs.edit();
+                                editor.putInt(device.getAddress() + "_battery_percent", level);
+                                editor.apply();
+                                device.setBatteryThresholdPercent((short) level);
+                            }
+                        });
+                alertDialog.show();
+
+            }
+        });
+        //Alberto soglia
 
         //fetch activity data
         holder.fetchActivityDataBox.setVisibility((device.isInitialized() && coordinator.supportsActivityDataFetching()) ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/hplus/HPlusCoordinator.java
@@ -289,6 +289,6 @@ public class HPlusCoordinator extends AbstractDeviceCoordinator {
     }
 
     public static boolean getUnicodeSupport(String address){
-        return (prefs.getBoolean(HPlusConstants.PREF_HPLUS_UNICODE, false));
+        return (prefs.getBoolean(HPlusConstants.PREF_HPLUS_UNICODE  + "_" + address, false));
     }
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
@@ -38,6 +38,7 @@ import nodomain.freeyourgadget.gadgetbridge.model.BatteryState;
 import nodomain.freeyourgadget.gadgetbridge.model.DeviceType;
 import nodomain.freeyourgadget.gadgetbridge.model.GenericItem;
 import nodomain.freeyourgadget.gadgetbridge.model.ItemWithDetails;
+import nodomain.freeyourgadget.gadgetbridge.util.Prefs;
 
 public class GBDevice implements Parcelable {
     public static final String ACTION_DEVICE_CHANGED
@@ -87,6 +88,10 @@ public class GBDevice implements Parcelable {
         mVolatileAddress = address2;
         mName = (name != null) ? name : mAddress;
         mDeviceType = deviceType;
+        //Alberto soglia
+        Prefs prefs = GBApplication.getPrefs();
+        mBatteryThresholdPercent = (short) prefs.getInt(mAddress + "_battery_percent", mBatteryThresholdPercent);
+        //Alberto soglia
         validate();
     }
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/impl/GBDevice.java
@@ -450,7 +450,7 @@ public class GBDevice implements Parcelable {
             result.add(new GenericItem(DEVINFO_FW_VER, mFirmwareVersion));
         }
         if (mFirmwareVersion2 != null) {
-            result.add(new GenericItem(DEVINFO_HR_VER, mFirmwareVersion2));
+          //  result.add(new GenericItem(DEVINFO_HR_VER, mFirmwareVersion2));
         }
         if (mAddress != null) {
             result.add(new GenericItem(DEVINFO_ADDR, mAddress));

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusHandlerThread.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusHandlerThread.java
@@ -363,13 +363,14 @@ class HPlusHandlerThread extends GBDeviceIoThread {
         //Skip when measuring heart rate
         //Calories and Distance are updated and these values will be lost.
         //Because a message with a valid Heart Rate will be provided, this loss very limited
-        if(record.heartRate == ActivityKind.TYPE_NOT_MEASURED) {
+        getDevice().setFirmwareVersion2(null);
+      /*  if(record.heartRate == ActivityKind.TYPE_NOT_MEASURED) {
             getDevice().setFirmwareVersion2("---");
             getDevice().sendDeviceUpdateIntent(getContext());
         }else {
             getDevice().setFirmwareVersion2("" + record.heartRate);
             getDevice().sendDeviceUpdateIntent(getContext());
-        }
+        }*/
 
         try (DBHandler dbHandler = GBApplication.acquireDB()) {
             HPlusHealthSampleProvider provider = new HPlusHealthSampleProvider(getDevice(), dbHandler.getDaoSession());

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -900,6 +900,12 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         }
         short level = bNormalize.getLevelNormalize((int) data,batteryCmd);
 
+        LOG.debug("Count:" + String.valueOf(bNormalize.getCounter()) +
+                " Mid:" + String.valueOf((int) level) +
+                " Band:" + String.valueOf((int) data) +
+                " Fix:" + String.valueOf(batteryCmd.level) +
+                " Time:" + String.valueOf(batteryCmd.lastChargeTime.getTimeInMillis()));
+
         if (batteryCmd.level != level) {
             SharedPreferences.Editor editor = settings.edit();
             if (level > batteryCmd.level) {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -49,6 +49,7 @@ import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusConstants;
 import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusCoordinator;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
 import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
+import nodomain.freeyourgadget.gadgetbridge.model.BatteryState;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CallSpec;
 import nodomain.freeyourgadget.gadgetbridge.model.CannedMessagesSpec;
@@ -883,10 +884,11 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     }
 
     private void handleBatteryInfo(byte data) {
-            if (batteryCmd.level != (short) data) {
-                batteryCmd.level = (short) data;
-                handleGBDeviceEvent(batteryCmd);
-            }
+        if (batteryCmd.level != (short) data) {
+            batteryCmd.level = (short) data;
+            batteryCmd.state = BatteryState.BATTERY_NORMAL;
+            handleGBDeviceEvent(batteryCmd);
+        }
     }
 
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -893,8 +893,8 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         SharedPreferences settings = GBApplication.getPrefs().getPreferences();
         if (batteryCmd.lastChargeTime == null) {
             batteryCmd.lastChargeTime = new GregorianCalendar();
-            batteryCmd.lastChargeTime.setTimeInMillis(settings.getLong("lastChargeTime", Calendar.getInstance().getTimeInMillis()));
-            batteryCmd.level = (short) settings.getInt("lastBatteryLevel", 0);
+            batteryCmd.lastChargeTime.setTimeInMillis(settings.getLong(getDevice().getAddress() + "_lastChargeTime", Calendar.getInstance().getTimeInMillis()));
+            batteryCmd.level = (short) settings.getInt(getDevice().getAddress() + "_lastBatteryLevel", 0);
             batteryCmd.state = BatteryState.BATTERY_NORMAL;
             batteryCmd.numCharges = 0;
         }
@@ -904,10 +904,10 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             SharedPreferences.Editor editor = settings.edit();
             if (level > batteryCmd.level) {
                 batteryCmd.lastChargeTime.setTimeInMillis(Calendar.getInstance().getTimeInMillis());
-                editor.putLong("lastChargeTime", batteryCmd.lastChargeTime.getTimeInMillis());
+                editor.putLong(getDevice().getAddress() + "_lastChargeTime", batteryCmd.lastChargeTime.getTimeInMillis());
             }
             batteryCmd.level = level;
-            editor.putInt("lastBatteryLevel", (int) batteryCmd.level);
+            editor.putInt(getDevice().getAddress() + "_lastBatteryLevel", (int) batteryCmd.level);
             editor.apply();
 
             handleGBDeviceEvent(batteryCmd);

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -68,6 +68,7 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile;
+import nodomain.freeyourgadget.gadgetbridge.util.BatteryNormalize;
 import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
@@ -81,6 +82,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     public BluetoothGattCharacteristic measureCharacteristic = null;
 
     private final GBDeviceEventBatteryInfo batteryCmd = new GBDeviceEventBatteryInfo();
+    private final BatteryNormalize bNormalize = new BatteryNormalize();
 
     private HPlusHandlerThread syncHelper;
     private DeviceType deviceType = DeviceType.UNKNOWN;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -904,7 +904,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
                 info += DEVINFO_CALORY + String.valueOf(record.calories) + "   ";
             }
             if (record.heartRate > 0 && record.heartRate != ActivityKind.TYPE_NOT_MEASURED) {
-                info += DEVINFO_HEART + String.valueOf(record.heartRate) + "   ";
+                info += "\n" + DEVINFO_HEART + String.valueOf(record.heartRate);
             }
 
             if (!info.equals("")) {

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -746,7 +746,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
             length = length > 5 ? 5 : length;
 
-            builder.write(ctrlCharacteristic, new byte[]{HPlusConstants.CMD_SET_INCOMING_MESSAGE, HPlusConstants.ARG_INCOMING_MESSAGE});
+           // builder.write(ctrlCharacteristic, new byte[]{HPlusConstants.CMD_SET_INCOMING_MESSAGE, HPlusConstants.ARG_INCOMING_MESSAGE});
 
             int remaining = Math.min(255, (messageBytes.length % 17 > 0) ? length + 1 : length);
 

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -673,7 +673,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         HPlusCoordinator.setUnicodeSupport(gbDevice.getAddress(), support);
     }
 
-    private void showIncomingCall_sendName(String name,TransactionBuilder builder) {
+    private void showIncomingCall_sendName(String name, TransactionBuilder builder) {
         if (name != null) {
             byte[] msg = new byte[13];
 
@@ -691,7 +691,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
             msg[0] = HPlusConstants.CMD_ACTION_DISPLAY_TEXT_NAME_CN;
             builder.write(ctrlCharacteristic, msg);
-        }else if (this.getDevice().getType() == DeviceType.MAKIBESF68){
+        } else if (this.getDevice().getType() == DeviceType.MAKIBESF68) {
             byte[] msg = new byte[13];
 
             //Show call name
@@ -706,7 +706,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         }
     }
 
-    private void showIncomingCall_sendNumber(String rawNumber,TransactionBuilder builder) {
+    private void showIncomingCall_sendNumber(String rawNumber, TransactionBuilder builder) {
         if (rawNumber != null) {
             StringBuilder number = new StringBuilder();
 
@@ -730,7 +730,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
             builder.wait(200);
             builder.write(ctrlCharacteristic, msg);
-        }else if (this.getDevice().getType() == DeviceType.MAKIBESF68){
+        } else if (this.getDevice().getType() == DeviceType.MAKIBESF68) {
             byte[] msg = new byte[13];
 
             //Show call number
@@ -739,7 +739,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
             msg[0] = HPlusConstants.CMD_SET_INCOMING_CALL_NUMBER;
 
-           // builder.wait(200);
+            // builder.wait(200);
             builder.write(ctrlCharacteristic, msg);
         }
     }
@@ -757,11 +757,11 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
 
             if (this.getDevice().getType() == DeviceType.MAKIBESF68) {
                 //ATTENTION,  MAKIBESF68 RESET DISPLAY ONLY WHEN SEND THE NUMBER,IF SEND FIRST NAME THE DISPLAY RETURN OLD NUMBER
-                showIncomingCall_sendNumber(rawNumber,builder);
-                showIncomingCall_sendName(name,builder);
+                showIncomingCall_sendNumber(rawNumber, builder);
+                showIncomingCall_sendName(name, builder);
             } else if (this.getDevice().getType() == DeviceType.HPLUS) {
-                showIncomingCall_sendName(name,builder);
-                showIncomingCall_sendNumber(rawNumber,builder);
+                showIncomingCall_sendName(name, builder);
+                showIncomingCall_sendNumber(rawNumber, builder);
             }
 
 
@@ -775,17 +775,28 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
     private void showText(String title, String body) {
         try {
             TransactionBuilder builder = performInitialized("notification");
-
             String message = "";
 
             if (title != null && title.length() > 0) {
-                message = StringUtils.pad(StringUtils.truncate(title, 16), 16); //Limit title to top row
+                if (getDevice().getType() == DeviceType.MAKIBESF68) {
+                    message = StringUtils.truncate(title, 9) + ":"; //Limit title to top row
+                    for (int i = message.length(); i < 10; i++)
+                        message += ' ';
+                }
+                if (getDevice().getType() == DeviceType.HPLUS) {
+                    message = StringUtils.pad(StringUtils.truncate(title, 16), 16); //Limit title to top row
+                }
+
             }
 
             if (body != null) {
-                message += body;
+                if (getDevice().getType() == DeviceType.MAKIBESF68) {
+                    message += StringUtils.truncate(body, 49 - message.length());
+                }
+                if (getDevice().getType() == DeviceType.HPLUS) {
+                    message += body;
+                }
             }
-
             byte[] messageBytes = encodeStringToDevice(message, HPlusConstants.CMD_ACTION_DISPLAY_TEXT);
 
             int length = messageBytes.length / 17;

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/hplus/HPlusSupport.java
@@ -27,6 +27,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.support.v4.content.LocalBroadcastManager;
 import android.widget.Toast;
@@ -43,12 +44,15 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import nodomain.freeyourgadget.gadgetbridge.GBApplication;
 import nodomain.freeyourgadget.gadgetbridge.R;
 import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventBatteryInfo;
 import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusConstants;
 import nodomain.freeyourgadget.gadgetbridge.devices.hplus.HPlusCoordinator;
 import nodomain.freeyourgadget.gadgetbridge.impl.GBDevice;
+import nodomain.freeyourgadget.gadgetbridge.model.ActivityKind;
 import nodomain.freeyourgadget.gadgetbridge.model.Alarm;
 import nodomain.freeyourgadget.gadgetbridge.model.BatteryState;
 import nodomain.freeyourgadget.gadgetbridge.model.CalendarEventSpec;
@@ -64,8 +68,10 @@ import nodomain.freeyourgadget.gadgetbridge.service.btle.AbstractBTLEDeviceSuppo
 import nodomain.freeyourgadget.gadgetbridge.service.btle.TransactionBuilder;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfo;
 import nodomain.freeyourgadget.gadgetbridge.service.btle.profiles.deviceinfo.DeviceInfoProfile;
+import nodomain.freeyourgadget.gadgetbridge.util.DateTimeUtils;
 import nodomain.freeyourgadget.gadgetbridge.util.GB;
 import nodomain.freeyourgadget.gadgetbridge.util.StringUtils;
+
 
 
 public class HPlusSupport extends AbstractBTLEDeviceSupport {
@@ -880,14 +886,12 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         try {
             HPlusDataRecordRealtime record = new HPlusDataRecordRealtime(data, HPlusCoordinator.getUserAge());
 
-            handleBatteryInfo(record.battery);
-
             String DEVINFO_STEP = getContext().getString(R.string.chart_steps) + ": ";
             String DEVINFO_DISTANCE = getContext().getString(R.string.distance) + ": ";
             String DEVINFO_CALORY = getContext().getString(R.string.calories) + ": ";
-            String DEVINFO_HEART = getContext().getString(R.string.charts_legend_heartrate);
+            String DEVINFO_HEART = getContext().getString(R.string.charts_legend_heartrate) + ": ";
 
-            String info = "";
+            String info = String.format(getContext().getString(R.string.notif_battery_low_bigtext_last_charge_time), getLastCharge(record.battery));
             if (record.steps > 0) {
                 info += DEVINFO_STEP + String.valueOf(record.steps) + "   ";
             }
@@ -897,7 +901,7 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
             if (record.calories > 0) {
                 info += DEVINFO_CALORY + String.valueOf(record.calories) + "   ";
             }
-            if (record.heartRate > 0) {
+            if (record.heartRate > 0 && record.heartRate != ActivityKind.TYPE_NOT_MEASURED) {
                 info += DEVINFO_HEART + String.valueOf(record.heartRate) + "   ";
             }
 
@@ -909,12 +913,40 @@ public class HPlusSupport extends AbstractBTLEDeviceSupport {
         }
     }
 
-    private void handleBatteryInfo(byte data) {
-        if (batteryCmd.level != (short) data) {
-            batteryCmd.level = (short) data;
+
+    private String getLastCharge(byte data) {
+        SharedPreferences settings = GBApplication.getPrefs().getPreferences();
+        if (batteryCmd.lastChargeTime == null) {
+            batteryCmd.lastChargeTime = new GregorianCalendar();
+            batteryCmd.lastChargeTime.setTimeInMillis(settings.getLong(getDevice().getAddress() + "_lastChargeTime", Calendar.getInstance().getTimeInMillis()));
+            batteryCmd.level = (short) settings.getInt(getDevice().getAddress() + "_lastBatteryLevel", 0);
             batteryCmd.state = BatteryState.BATTERY_NORMAL;
+            batteryCmd.numCharges = 0;
+        }
+        short level = bNormalize.getLevelNormalize((int) data,batteryCmd);
+
+        LOG.debug("Count:" + String.valueOf(bNormalize.getCounter()) +
+                " Mid:" + String.valueOf((int) level) +
+                " Band:" + String.valueOf((int) data) +
+                " Fix:" + String.valueOf(batteryCmd.level) +
+                " Time:" + String.valueOf(batteryCmd.lastChargeTime.getTimeInMillis()));
+
+        if (batteryCmd.level != level) {
+            SharedPreferences.Editor editor = settings.edit();
+            if (level > batteryCmd.level) {
+                batteryCmd.lastChargeTime.setTimeInMillis(Calendar.getInstance().getTimeInMillis());
+                editor.putLong(getDevice().getAddress() + "_lastChargeTime", batteryCmd.lastChargeTime.getTimeInMillis());
+            }
+            batteryCmd.level = level;
+            editor.putInt(getDevice().getAddress() + "_lastBatteryLevel", (int) batteryCmd.level);
+            editor.apply();
+
             handleGBDeviceEvent(batteryCmd);
         }
+
+        long difference = Calendar.getInstance().getTimeInMillis() - batteryCmd.lastChargeTime.getTimeInMillis();
+
+        return DateTimeUtils.formatDurationHoursMinutes(difference, TimeUnit.MILLISECONDS);
     }
 
 }

--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/BatteryNormalize.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/util/BatteryNormalize.java
@@ -1,0 +1,44 @@
+package nodomain.freeyourgadget.gadgetbridge.util;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import nodomain.freeyourgadget.gadgetbridge.deviceevents.GBDeviceEventBatteryInfo;
+
+/**
+ * Created by Raziel on 13/04/2017.
+ */
+
+public class BatteryNormalize {
+    private int counter = 0;
+    private int levelMid = 0;
+    private GregorianCalendar lastCheck = new GregorianCalendar();
+    private static int INTERVAL_SECOND_CHECK  = 30;
+    private static int MAX_COUNT_CHECK = 6;
+
+    public void BatteryNormalize(int interval,int numerberCheck){
+        INTERVAL_SECOND_CHECK=interval;
+        MAX_COUNT_CHECK=numerberCheck;
+    }
+
+    //use this function if the battery level of the device oscillates
+    public short getLevelNormalize(int data, GBDeviceEventBatteryInfo cmd) {
+        if ((Calendar.getInstance().getTimeInMillis()-lastCheck.getTimeInMillis() ) / 1000 >= INTERVAL_SECOND_CHECK) {
+            lastCheck.setTimeInMillis(Calendar.getInstance().getTimeInMillis());
+            if (data > levelMid || counter == 0) {
+                levelMid = data;
+            }
+            counter += 1;
+        }
+        if (counter == MAX_COUNT_CHECK) {
+            counter = 0;
+            return (short) levelMid;
+        } else {
+            return cmd.level;
+        }
+    }
+
+    public int getCounter  (){
+        return  counter;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="pref_pebble_privacy_mode_off">Normal notifications</string>
     <string name="pref_pebble_privacy_mode_content">Shift the notification text off-screen</string>
     <string name="pref_pebble_privacy_mode_complete">Show only the notification icon</string>
+    <string name="pref_title_battery_percent">Threshold battery notification discharge</string>
 
     <string name="pref_header_location">Location</string>
     <string name="pref_title_location_aquire">Acquire Location</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Hi barraca, I added a new device similar to makibes, it is called s200.
Watch showIncomingCall,
EncodeStringToDevice, the other are my changes.

I noticed that the unicode encodin only works on text messages, and for every unicode character he inserts the bytes -1, -2, <char>, 0 this is fine for the first character for the next, this sequence creates a space therefore i So that -1 and -2 are valid only for the first character

Regarding the calls he works with a GB2312 encoding, the device also has a cache that is emptied only if it sends it as first given the phone number, so it is necessary to send in order rawnumber and name,
Even if one of the null is null you must also send the data blank.

I do not know if this facility is good for other devices that support unicode but for s200 this is fine


About HPlusCoordinator
I made the following correction

Static Boolean public getUnicodeSupport (string address) {
Returns (prefs.getBoolean (HPlusConstants.PREF_HPLUS_UNICODE + "_" + address, false));
}